### PR TITLE
[yumemi] Improve speed by using HashMap instead of Vec in GameScoreSummary

### DIFF
--- a/yumemi/src/game_score.rs
+++ b/yumemi/src/game_score.rs
@@ -1,4 +1,5 @@
 use csv::{Reader, Writer};
+use std::collections::HashMap;
 use std::fs::File;
 use std::io::{self, BufReader};
 // create_timestamp,player_id,score
@@ -35,12 +36,11 @@ struct GameScoreRank {
 }
 
 #[derive(Debug)]
-// TODO: struct GameScoreSummary(HashMap<String, GameScore>); にする
-struct GameScoreSummary(Vec<GameScore>);
+struct GameScoreSummary(HashMap<String, GameScore>);
 
 impl GameScoreSummary {
     fn new() -> Self {
-        Self(Vec::new())
+        Self(HashMap::new())
     }
 
     fn upsert(&mut self, new_score: GameScore) {
@@ -55,12 +55,11 @@ impl GameScoreSummary {
     }
 
     fn find(&mut self, player_id: String) -> Option<&mut GameScore> {
-        // TODO: この find で全件捜査して時間かかってるので HashMap での key アクセスに変える
-        self.0.iter_mut().find(|score| score.player_id == player_id)
+        self.0.get_mut(&player_id)
     }
 
     fn insert(&mut self, new_score: GameScore) {
-        self.0.push(new_score);
+        self.0.insert(new_score.clone().player_id, new_score);
     }
 
     fn to_ranks(&self, limit: u32) -> Vec<GameScoreRank> {
@@ -109,10 +108,10 @@ impl GameScoreSummary {
 
     fn to_means(&self) -> Vec<GameScoreMean> {
         let mut game_score_means: Vec<GameScoreMean> = Vec::new();
-        for score in &self.0 {
+        for (player_id, score) in &self.0 {
             let mean_score = score.sum / score.play_count;
             let game_score_mean = GameScoreMean {
-                player_id: score.clone().player_id,
+                player_id: player_id.to_string(),
                 score: mean_score,
             };
             game_score_means.push(game_score_mean);


### PR DESCRIPTION
## Overview

upsert の部分で Vec を検索（線形探索）して O(n) かけてしまっていた部分を HashMap（ハッシュテーブル）を使い、O(1) で実現するようにした。

See. [ハッシュテーブル \- Wikipedia](https://ja.wikipedia.org/wiki/%E3%83%8F%E3%83%83%E3%82%B7%E3%83%A5%E3%83%86%E3%83%BC%E3%83%96%E3%83%AB)

### MBP（メモリ32GB）で実行した結果

30万件の場合、96.3秒 -> 1.2秒まで高速化できた 👏 
ただ「3000万件を10秒程度で」が目標だったところ、126秒もかかってしまっているのでさらに高速化の余地はある。

```sh
# before
❯ cargo run gen_csv 300000 # 30万件
    Finished dev [unoptimized + debuginfo] target(s) in 0.03s
     Running `target/debug/yumemi gen_csv 300000`
❯ cargo run
    Finished dev [unoptimized + debuginfo] target(s) in 0.03s
     Running `target/debug/yumemi`
rank,player_id,mean_score
1,player434,7384
2,player7110,7184
3,player5238,7018
4,player1155,6874
5,player6309,6869
6,player980,6865
7,player8747,6808
8,player3541,6792
9,player8178,6753
10,player3419,6743
time: 96.299 seconds
# 300万件の場合は終了せず

# after
❯ cargo run gen_csv 300000 # 30万件
   Compiling yumemi v0.1.0 (/Users/daido1976/ghq/github.com/daido1976/learn-rust/yumemi)
    Finished dev [unoptimized + debuginfo] target(s) in 1.54s
     Running `target/debug/yumemi gen_csv 300000`
❯ cargo run
    Finished dev [unoptimized + debuginfo] target(s) in 0.03s
     Running `target/debug/yumemi`
rank,player_id,mean_score
1,player5442,7573
2,player9913,7281
3,player2146,6875
4,player4441,6809
5,player8066,6807
6,player2446,6752
7,player7562,6731
8,player9494,6712
9,player1860,6707
10,player8878,6680
time: 1.246 seconds
❯ cargo run gen_csv 3000000 # 300万件
    Finished dev [unoptimized + debuginfo] target(s) in 0.03s
     Running `target/debug/yumemi gen_csv 3000000`
❯ cargo run
    Finished dev [unoptimized + debuginfo] target(s) in 0.02s
     Running `target/debug/yumemi`
rank,player_id,mean_score
1,player2774,5722
2,player1702,5686
3,player4861,5607
4,player6894,5577
5,player3200,5539
6,player4385,5526
7,player2275,5517
8,player1305,5511
9,player2229,5489
10,player6797,5486
time: 12.502 seconds

❯ cargo run gen_csv 30000000 # 3000万件
    Finished dev [unoptimized + debuginfo] target(s) in 0.03s
     Running `target/debug/yumemi gen_csv 30000000`
❯ cargo run
    Finished dev [unoptimized + debuginfo] target(s) in 0.04s
     Running `target/debug/yumemi`
rank,player_id,mean_score
1,player4579,5182
1,player3960,5182
3,player8969,5171
4,player2196,5169
5,player3512,5165
6,player7053,5164
7,player6797,5163
7,player5130,5163
7,player4616,5163
10,player238,5161
time: 126.274 seconds
```

<details>
<summary>MBA（メモリ8GB） で実行した結果</summary>

```sh
# Before
❯ cargo run gen_csv 30000
    Finished dev [unoptimized + debuginfo] target(s) in 0.41s
     Running `target/debug/yumemi gen_csv 30000`
❯ cargo run
    Finished dev [unoptimized + debuginfo] target(s) in 0.06s
     Running `target/debug/yumemi`
rank,player_id,mean_score
1,player8549,9996
2,player2651,9981
3,player5824,9976
4,player2718,9975
5,player5288,9971
6,player9634,9955
7,player5155,9937
8,player1666,9928
9,player7513,9926
10,player877,9909
time: 22.484 seconds

# 30万件の場合は終了せず

# After
$ cargo run gen_csv 30000
    Finished dev [unoptimized + debuginfo] target(s) in 0.06s
     Running `target/debug/yumemi gen_csv 30000`
$ cargo run
    Finished dev [unoptimized + debuginfo] target(s) in 0.06s
     Running `target/debug/yumemi`
rank,player_id,mean_score
1,player8420,9997
2,player3340,9994
3,player3673,9986
4,player8695,9978
5,player6389,9975
6,player8650,9968
7,player4171,9966
8,player5485,9964
8,player201,9964
10,player17,9943
time: 0.253 seconds
$ cargo run gen_csv 300000
    Finished dev [unoptimized + debuginfo] target(s) in 0.31s
     Running `target/debug/yumemi gen_csv 300000`
$ cargo run
    Finished dev [unoptimized + debuginfo] target(s) in 0.06s
     Running `target/debug/yumemi`
rank,player_id,mean_score
1,player7704,7123
2,player6511,7032
2,player4298,7032
4,player7999,6945
5,player9577,6944
5,player845,6944
7,player6582,6919
8,player5205,6893
9,player4200,6886
10,player3622,6882
time: 2.327 seconds
$ cargo run gen_csv 3000000
    Finished dev [unoptimized + debuginfo] target(s) in 0.06s
     Running `target/debug/yumemi gen_csv 3000000`
$ cargo run
    Finished dev [unoptimized + debuginfo] target(s) in 0.10s
     Running `target/debug/yumemi`
rank,player_id,mean_score
1,player7495,5650
2,player8477,5610
3,player1416,5607
4,player6741,5582
5,player8647,5577
6,player4315,5542
7,player2196,5537
8,player5565,5535
9,player4319,5534
10,player9026,5526
time: 25.835 seconds

# 3000万件の場合は終了せず
```

</details>